### PR TITLE
fix HTTP 406 bug importing to Elasticsearch 7.16

### DIFF
--- a/tools/export.go
+++ b/tools/export.go
@@ -20,6 +20,7 @@ func Export(host string, index string, search string, w io.Writer) (int, error) 
 	// Dump mapping first
 	rootIndexURI := fmt.Sprintf("http://%s/%s", host, index)
 	req, err := http.NewRequest("GET", rootIndexURI, nil)
+    req.Header.Add("Content-Type", "application/json")
 	if err != nil {
 		return 0, err
 	}
@@ -43,6 +44,7 @@ func Export(host string, index string, search string, w io.Writer) (int, error) 
 	}
 	uri := fmt.Sprintf("%s/_search?size=10000&scroll=1m", rootIndexURI)
 	req, err = http.NewRequest("POST", uri, body)
+    req.Header.Add("Content-Type", "application/json")
 	if err != nil {
 		return 0, err
 	}
@@ -95,6 +97,7 @@ func Export(host string, index string, search string, w io.Writer) (int, error) 
 		uri := fmt.Sprintf("%s/_search/scroll", rootURI)
 		postBody := fmt.Sprintf(`{"scroll":"1m","scroll_id":"%s"}`, scrollID.String())
 		req, err := http.NewRequest("POST", uri, strings.NewReader(postBody))
+        req.Header.Add("Content-Type", "application/json")
 		if err != nil {
 			return 0, err
 		}

--- a/tools/import.go
+++ b/tools/import.go
@@ -55,6 +55,7 @@ func Import(host string, index string, workers int, nocreate bool, shards int, r
 			}
 		}
 		req, err := http.NewRequest("PUT", rootURI, strings.NewReader(mapping))
+        req.Header.Add("Content-Type", "application/json")
 		if err != nil {
 			return 0, err
 		}
@@ -102,6 +103,7 @@ func importWorker(wg *sync.WaitGroup, docsChan chan string, progress *util.Progr
 		source := gjson.Get(doc, "_source").String()
 		uri := fmt.Sprintf("%s/%s/%s", rootURI, dtype, id)
 		req, err := http.NewRequest("PUT", uri, strings.NewReader(source))
+        req.Header.Add("Content-Type", "application/json")
 		if err != nil {
 			fmt.Printf("error creating PUT request: %s\n", err.Error())
 			continue

--- a/tools/reshard.go
+++ b/tools/reshard.go
@@ -71,6 +71,7 @@ func Reshard(host string, index string, dir string, keep bool, search string, wo
 func deleteIndex(host, index string) error {
 	indexURI := fmt.Sprintf("http://%s/%s", host, index)
 	req, err := http.NewRequest("DELETE", indexURI, nil)
+    req.Header.Add("Content-Type", "application/json")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The import function misses JSON header against Elasticsearch 7.16

[This request](https://github.com/binwiederhier/elastictl/blob/c2b82b4a6e314c62c13eb5fa86fa076cd105e9fa/tools/import.go#L61) in `Import()` returns HTTP 406:
> unexpected response code during index creation: 406

[This request](https://github.com/binwiederhier/elastictl/blob/c2b82b4a6e314c62c13eb5fa86fa076cd105e9fa/tools/import.go#L109) of each worker also returns HTTP 406:
> PUT returned unexpected response: 406

Adding the JSON header fixes the issue.

The export/reshard functions misses JSON header as well, resulting the error msg (export):

> no scroll id: {"error":"Content-Type header [] is not supported","status":406}